### PR TITLE
Fix BuildRequirementProjectsFilter

### DIFF
--- a/src/main/java/org/commonjava/maven/cartographer/preset/BuildRequirementProjectsFilter.java
+++ b/src/main/java/org/commonjava/maven/cartographer/preset/BuildRequirementProjectsFilter.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the GNU Public License v3.0
  * which accompanies this distribution, and is available at
  * http://www.gnu.org/licenses/gpl.html
- * 
+ *
  * Contributors:
  *     Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
@@ -74,7 +74,7 @@ public class BuildRequirementProjectsFilter
         //        logger.info( "Creating filter {}",
         //                     runtimeOnly ? "for runtime artifacts ONLY - only dependencies in the runtime/compile scope."
         //                                     : "for any artifact" );
-        this( runtimeOnly, acceptManaged, acceptBOMs, excludes, 
+        this( runtimeOnly, acceptManaged, acceptBOMs, excludes,
               runtimeOnly ? new OrFilter( new DependencyFilter( DependencyScope.runtime, ScopeTransitivity.maven, false,
                                                                 true, excludes ),
                                           new DependencyFilter( DependencyScope.embedded, ScopeTransitivity.maven, false,
@@ -159,10 +159,13 @@ public class BuildRequirementProjectsFilter
                     if ( excludes != null )
                     {
                         exc = new HashSet<ProjectRef>( excludes );
+                        exc.addAll( dr.getExcludes() );
+                        construct = exc.equals( dr.getExcludes() );
                     }
-
-                    exc.addAll( dr.getExcludes() );
-                    construct = exc.equals( dr.getExcludes() );
+                    else
+                    {
+                        construct = true;
+                    }
                 }
 
                 boolean nextRuntimeOnly = runtimeOnly;

--- a/src/main/java/org/commonjava/maven/cartographer/preset/BuildRequirementProjectsFilter.java
+++ b/src/main/java/org/commonjava/maven/cartographer/preset/BuildRequirementProjectsFilter.java
@@ -160,7 +160,7 @@ public class BuildRequirementProjectsFilter
                     {
                         exc = new HashSet<ProjectRef>( excludes );
                         exc.addAll( dr.getExcludes() );
-                        construct = exc.equals( dr.getExcludes() );
+                        construct = !exc.equals( dr.getExcludes() );
                     }
                     else
                     {


### PR DESCRIPTION
* exc was used even though it was not initialized
* construct was set to true only if the excludes did not change while it makes sense in the opposite case, i.e. only when it changed