### PR TITLE
Accept all BOMs even in transitive dependency tree

### DIFF
--- a/src/main/java/org/commonjava/maven/cartographer/preset/BuildRequirementProjectsFilter.java
+++ b/src/main/java/org/commonjava/maven/cartographer/preset/BuildRequirementProjectsFilter.java
@@ -45,8 +45,6 @@ public class BuildRequirementProjectsFilter
 
     private final Set<ProjectRef> excludes;
 
-    private final boolean acceptBOMs;
-
     private final boolean acceptManaged;
 
     private transient String longId;
@@ -60,21 +58,16 @@ public class BuildRequirementProjectsFilter
 
     public BuildRequirementProjectsFilter( final boolean acceptManaged )
     {
-        this( acceptManaged, true );
-    }
-
-    public BuildRequirementProjectsFilter( final boolean acceptManaged, final boolean acceptBOMs )
-    {
-        this( false, acceptManaged, acceptBOMs, null, null );
+        this( false, acceptManaged, null, null );
     }
 
     private BuildRequirementProjectsFilter( final boolean runtimeOnly, final boolean acceptManaged,
-                                            final boolean acceptBOMs, final Set<ProjectRef> excludes )
+                                            final Set<ProjectRef> excludes )
     {
         //        logger.info( "Creating filter {}",
         //                     runtimeOnly ? "for runtime artifacts ONLY - only dependencies in the runtime/compile scope."
         //                                     : "for any artifact" );
-        this( runtimeOnly, acceptManaged, acceptBOMs, excludes,
+        this( runtimeOnly, acceptManaged, excludes,
               runtimeOnly ? new OrFilter( new DependencyFilter( DependencyScope.runtime, ScopeTransitivity.maven, false,
                                                                 true, excludes ),
                                           new DependencyFilter( DependencyScope.embedded, ScopeTransitivity.maven, false,
@@ -84,14 +77,12 @@ public class BuildRequirementProjectsFilter
     }
 
     private BuildRequirementProjectsFilter( final boolean runtimeOnly, final boolean acceptManaged,
-                                            final boolean acceptBOMs, final Set<ProjectRef> excludes,
-                                            final ProjectRelationshipFilter filter )
+                                            final Set<ProjectRef> excludes, final ProjectRelationshipFilter filter )
     {
         //        logger.info( "Creating filter {}",
         //                     runtimeOnly ? "for runtime artifacts ONLY - only dependencies in the runtime/compile scope."
         //                                     : "for any artifact" );
         this.runtimeOnly = runtimeOnly;
-        this.acceptBOMs = acceptBOMs;
         this.acceptManaged = acceptManaged;
         this.filter = filter;
         this.excludes = excludes;
@@ -108,7 +99,7 @@ public class BuildRequirementProjectsFilter
         }
         else if ( rel.getType() == BOM )
         {
-            result = acceptBOMs;
+            result = true;
         }
         else if ( !acceptManaged && rel.isManaged() )
         {
@@ -143,7 +134,7 @@ public class BuildRequirementProjectsFilter
             case PLUGIN:
             case PLUGIN_DEP:
             {
-                return new BuildRequirementProjectsFilter( true, false, false, excludes );
+                return new BuildRequirementProjectsFilter( true, false, excludes );
             }
             default:
             {
@@ -200,8 +191,7 @@ public class BuildRequirementProjectsFilter
 
                 if ( construct )
                 {
-                    return new BuildRequirementProjectsFilter( nextRuntimeOnly, acceptManaged && nextRuntimeOnly, false,
-                                                               exc );
+                    return new BuildRequirementProjectsFilter( nextRuntimeOnly, acceptManaged && nextRuntimeOnly, exc );
                 }
 
                 return this;
@@ -220,7 +210,6 @@ public class BuildRequirementProjectsFilter
     {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ( acceptBOMs ? 727 : 733 );
         result = prime * result + ( acceptManaged ? 1231 : 1237 );
         result = prime * result + ( ( excludes == null ) ? 0 : excludes.hashCode() );
         result = prime * result + ( ( filter == null ) ? 0 : filter.hashCode() );
@@ -244,10 +233,6 @@ public class BuildRequirementProjectsFilter
             return false;
         }
         final BuildRequirementProjectsFilter other = (BuildRequirementProjectsFilter) obj;
-        if ( acceptBOMs != other.acceptBOMs )
-        {
-            return false;
-        }
         if ( acceptManaged != other.acceptManaged )
         {
             return false;
@@ -304,8 +289,6 @@ public class BuildRequirementProjectsFilter
               .append( new JoinString( ",", excludes ) )
               .append( "},acceptManaged:" )
               .append( acceptManaged )
-              .append( "},acceptBOMs:" )
-              .append( acceptBOMs )
               .append( ")" );
 
             longId = sb.toString();

--- a/src/main/java/org/commonjava/maven/cartographer/preset/ScopeWithEmbeddedProjectsFilter.java
+++ b/src/main/java/org/commonjava/maven/cartographer/preset/ScopeWithEmbeddedProjectsFilter.java
@@ -38,13 +38,9 @@ public class ScopeWithEmbeddedProjectsFilter
 
     private static final long serialVersionUID = 1L;
 
-    private static final boolean DEFAULT_CHILD_ACCEPTBOMS = false;
-
     private static final boolean DEFAULT_CHILD_ACCEPTMANAGED = false;
 
     private final ProjectRelationshipFilter filter;
-
-    private final boolean acceptBOMs;
 
     private final boolean acceptManaged;
 
@@ -56,7 +52,6 @@ public class ScopeWithEmbeddedProjectsFilter
 
     public ScopeWithEmbeddedProjectsFilter( final DependencyScope scope, final boolean acceptManaged )
     {
-        this.acceptBOMs = true;
         this.scope = scope == null ? DependencyScope.runtime : scope;
         this.acceptManaged = acceptManaged;
         this.filter =
@@ -67,7 +62,6 @@ public class ScopeWithEmbeddedProjectsFilter
 
     private ScopeWithEmbeddedProjectsFilter( final DependencyScope scope, final ProjectRelationshipFilter childFilter )
     {
-        this.acceptBOMs = DEFAULT_CHILD_ACCEPTBOMS;
         this.acceptManaged = DEFAULT_CHILD_ACCEPTMANAGED;
         this.filter =
             childFilter == null ? new OrFilter( new DependencyFilter( scope, ScopeTransitivity.maven, false, true,
@@ -87,7 +81,7 @@ public class ScopeWithEmbeddedProjectsFilter
         }
         else if ( rel.getType() == BOM )
         {
-            result = acceptBOMs;
+            result = true;
         }
         else if ( !acceptManaged && rel.isManaged() )
         {
@@ -140,8 +134,7 @@ public class ScopeWithEmbeddedProjectsFilter
                 final DependencyRelationship dr = (DependencyRelationship) lastRelationship;
                 if ( DependencyScope.test == dr.getScope() || DependencyScope.provided == dr.getScope() )
                 {
-                    if ( acceptBOMs == DEFAULT_CHILD_ACCEPTBOMS && acceptManaged == DEFAULT_CHILD_ACCEPTMANAGED
-                            && filter == NoneFilter.INSTANCE )
+                    if ( acceptManaged == DEFAULT_CHILD_ACCEPTMANAGED && filter == NoneFilter.INSTANCE )
                     {
                         return this;
                     }
@@ -151,8 +144,7 @@ public class ScopeWithEmbeddedProjectsFilter
                 }
 
                 final ProjectRelationshipFilter nextFilter = filter.getChildFilter( lastRelationship );
-                if ( acceptBOMs == DEFAULT_CHILD_ACCEPTBOMS && acceptManaged == DEFAULT_CHILD_ACCEPTMANAGED
-                        && nextFilter == filter )
+                if ( acceptManaged == DEFAULT_CHILD_ACCEPTMANAGED && nextFilter == filter )
                 {
                     return this;
                 }
@@ -181,8 +173,6 @@ public class ScopeWithEmbeddedProjectsFilter
 
             sb.append( ",acceptManaged:" )
               .append( acceptManaged )
-              .append( ",acceptBOMs:" )
-              .append( acceptBOMs )
               .append( ")" );
 
             longId = sb.toString();
@@ -202,7 +192,6 @@ public class ScopeWithEmbeddedProjectsFilter
     {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ( acceptBOMs ? 727 : 733 );
         result = prime * result + ( acceptManaged ? 1231 : 1237 );
         result = prime * result + filter.hashCode();
         result = prime * result + ( ( scope == null ) ? 0 : scope.hashCode() );
@@ -225,10 +214,6 @@ public class ScopeWithEmbeddedProjectsFilter
             return false;
         }
         final ScopeWithEmbeddedProjectsFilter other = (ScopeWithEmbeddedProjectsFilter) obj;
-        if ( acceptBOMs != other.acceptBOMs )
-        {
-            return false;
-        }
         if ( acceptManaged != other.acceptManaged )
         {
             return false;
@@ -272,10 +257,7 @@ public class ScopeWithEmbeddedProjectsFilter
     {
         final Set<RelationshipType> types = new HashSet<>();
         types.add( PARENT );
-        if ( acceptBOMs )
-        {
-            types.add( BOM );
-        }
+        types.add( BOM );
 
         types.addAll( filter.getAllowedTypes() );
 

--- a/src/test/java/org/commonjava/maven/cartographer/preset/BuildRequirementProjectsFilterTest.java
+++ b/src/test/java/org/commonjava/maven/cartographer/preset/BuildRequirementProjectsFilterTest.java
@@ -88,7 +88,7 @@ public class BuildRequirementProjectsFilterTest
         final ProjectRelationshipFilter child = filter.getChildFilter( plugin );
         assertConcreteAcceptance( child, from, src, tgt,
                                   new HashSet<DependencyScope>( Arrays.asList( embedded, runtime, compile ) ),
-                                  DEPENDENCY, PARENT );
+                                  DEPENDENCY, PARENT, BOM );
 
         assertRejectsAllManaged( child, from, src, tgt );
     }
@@ -102,7 +102,7 @@ public class BuildRequirementProjectsFilterTest
         final ProjectRelationshipFilter child = filter.getChildFilter( plugin );
         assertConcreteAcceptance( child, from, src, tgt,
                                   new HashSet<DependencyScope>( Arrays.asList( embedded, runtime, compile ) ),
-                                  DEPENDENCY, PARENT );
+                                  DEPENDENCY, PARENT, BOM );
 
         assertRejectsAllManaged( child, from, src, tgt );
     }
@@ -118,7 +118,7 @@ public class BuildRequirementProjectsFilterTest
 
         assertConcreteAcceptance( child, from, src, tgt,
                                   new HashSet<DependencyScope>( Arrays.asList( embedded, runtime, compile ) ),
-                                  DEPENDENCY, PARENT );
+                                  DEPENDENCY, PARENT, BOM );
 
         assertRejectsAllManaged( child, from, src, tgt );
     }
@@ -134,7 +134,7 @@ public class BuildRequirementProjectsFilterTest
 
         assertConcreteAcceptance( child, from, src, tgt,
                                   new HashSet<DependencyScope>( Arrays.asList( embedded, runtime, compile ) ),
-                                  DEPENDENCY, PARENT );
+                                  DEPENDENCY, PARENT, BOM );
 
         assertRejectsAllManaged( child, from, src, tgt );
     }

--- a/src/test/java/org/commonjava/maven/cartographer/preset/ScopeWithEmbeddedProjectsFilterTest.java
+++ b/src/test/java/org/commonjava/maven/cartographer/preset/ScopeWithEmbeddedProjectsFilterTest.java
@@ -111,7 +111,7 @@ public class ScopeWithEmbeddedProjectsFilterTest
 
         final ProjectRelationshipFilter child = filter.getChildFilter( dep );
 
-        assertConcreteAcceptance( child, from, src, tgt, new HashSet<DependencyScope>(), PARENT );
+        assertConcreteAcceptance( child, from, src, tgt, new HashSet<DependencyScope>(), BOM, PARENT );
 
         assertRejectsAllManaged( child, from, src, tgt );
     }
@@ -125,13 +125,13 @@ public class ScopeWithEmbeddedProjectsFilterTest
 
         final ProjectRelationshipFilter child = filter.getChildFilter( dep );
 
-        assertConcreteAcceptance( child, from, src, tgt, new HashSet<DependencyScope>(), PARENT );
+        assertConcreteAcceptance( child, from, src, tgt, new HashSet<DependencyScope>(), BOM, PARENT );
 
         assertRejectsAllManaged( child, from, src, tgt );
     }
 
     @Test
-    public void acceptAllEmbeddedAndRuntimeAndCompileDependenciesWithParentsAfterTraversingRuntimeDependency()
+    public void acceptAllEmbeddedAndRuntimeAndCompileDependenciesWithParentsAndBomsAfterTraversingRuntimeDependency()
         throws Exception
     {
         final DependencyRelationship dep =
@@ -141,13 +141,13 @@ public class ScopeWithEmbeddedProjectsFilterTest
 
         assertConcreteAcceptance( child, from, src, tgt,
                                   new HashSet<DependencyScope>( Arrays.asList( embedded, runtime, compile ) ),
-                                  DEPENDENCY, PARENT );
+                                  DEPENDENCY, PARENT, BOM );
 
         assertRejectsAllManaged( child, from, src, tgt );
     }
 
     @Test
-    public void acceptAllEmbeddedAndRuntimeAndCompileDependenciesWithParentsAfterTraversingCompileDependency()
+    public void acceptAllEmbeddedAndRuntimeAndCompileDependenciesWithParentsAndBomsAfterTraversingCompileDependency()
         throws Exception
     {
         final DependencyRelationship dep =
@@ -157,7 +157,7 @@ public class ScopeWithEmbeddedProjectsFilterTest
 
         assertConcreteAcceptance( child, from, src, tgt,
                                   new HashSet<DependencyScope>( Arrays.asList( embedded, runtime, compile ) ),
-                                  DEPENDENCY, PARENT );
+                                  DEPENDENCY, PARENT, BOM );
 
         assertRejectsAllManaged( child, from, src, tgt );
     }


### PR DESCRIPTION
If there is a dependency without version in a dependency and there is no version
specified in the dependencyManagement of the root artifact, then the version from
the dependencyManagement of the dependency is used. So we need to include all
BOMs imported in the transitive dependency tree.