### PR TITLE
Filters refactoring

### DIFF
--- a/src/main/java/org/commonjava/maven/cartographer/preset/BuildRequirementProjectsFilter.java
+++ b/src/main/java/org/commonjava/maven/cartographer/preset/BuildRequirementProjectsFilter.java
@@ -108,7 +108,7 @@ public class BuildRequirementProjectsFilter
             case PLUGIN:
             case PLUGIN_DEP:
             {
-                return new ScopeWithEmbeddedProjectsFilter( DependencyScope.runtime, false );
+                return new ScopeWithEmbeddedProjectsFilter( DependencyScope.runtime, acceptManaged );
             }
             default:
             {

--- a/src/main/java/org/commonjava/maven/cartographer/preset/ScopeWithEmbeddedProjectsFilter.java
+++ b/src/main/java/org/commonjava/maven/cartographer/preset/ScopeWithEmbeddedProjectsFilter.java
@@ -41,8 +41,6 @@ public class ScopeWithEmbeddedProjectsFilter
 
     private static final long serialVersionUID = 1L;
 
-    private static final boolean DEFAULT_CHILD_ACCEPTMANAGED = false;
-
     private final ProjectRelationshipFilter filter;
 
     private final Set<ProjectRef> excludes;
@@ -174,13 +172,13 @@ public class ScopeWithEmbeddedProjectsFilter
                 }
 
                 final ProjectRelationshipFilter nextFilter = filter.getChildFilter( lastRelationship );
-                if ( filter.equals( nextFilter ) && acceptManaged == DEFAULT_CHILD_ACCEPTMANAGED && !excChanged )
+                if ( filter.equals( nextFilter ) && !excChanged )
                 {
                     return this;
                 }
                 else
                 {
-                    return new ScopeWithEmbeddedProjectsFilter( nextFilter, DEFAULT_CHILD_ACCEPTMANAGED, exc );
+                    return new ScopeWithEmbeddedProjectsFilter( nextFilter, acceptManaged, exc );
                 }
             }
         }

--- a/src/main/java/org/commonjava/maven/cartographer/preset/ScopeWithEmbeddedProjectsFilter.java
+++ b/src/main/java/org/commonjava/maven/cartographer/preset/ScopeWithEmbeddedProjectsFilter.java
@@ -11,6 +11,7 @@
 package org.commonjava.maven.cartographer.preset;
 
 import static org.commonjava.maven.atlas.graph.rel.RelationshipType.BOM;
+import static org.commonjava.maven.atlas.graph.rel.RelationshipType.DEPENDENCY;
 import static org.commonjava.maven.atlas.graph.rel.RelationshipType.PARENT;
 
 import java.util.HashSet;
@@ -27,6 +28,8 @@ import org.commonjava.maven.atlas.graph.rel.ProjectRelationship;
 import org.commonjava.maven.atlas.graph.rel.RelationshipType;
 import org.commonjava.maven.atlas.ident.DependencyScope;
 import org.commonjava.maven.atlas.ident.ScopeTransitivity;
+import org.commonjava.maven.atlas.ident.ref.ProjectRef;
+import org.commonjava.maven.atlas.ident.util.JoinString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,9 +45,9 @@ public class ScopeWithEmbeddedProjectsFilter
 
     private final ProjectRelationshipFilter filter;
 
-    private final boolean acceptManaged;
+    private final Set<ProjectRef> excludes;
 
-    private DependencyScope scope;
+    private final boolean acceptManaged;
 
     private transient String longId;
 
@@ -52,23 +55,26 @@ public class ScopeWithEmbeddedProjectsFilter
 
     public ScopeWithEmbeddedProjectsFilter( final DependencyScope scope, final boolean acceptManaged )
     {
-        this.scope = scope == null ? DependencyScope.runtime : scope;
+        this( scope, acceptManaged, null );
+    }
+    
+    ScopeWithEmbeddedProjectsFilter( final DependencyScope scope, final boolean acceptManaged, Set<ProjectRef> exc )
+    {
+        DependencyScope filterScope = scope == null ? DependencyScope.runtime : scope;
         this.acceptManaged = acceptManaged;
         this.filter =
-            new OrFilter( new DependencyFilter( this.scope, ScopeTransitivity.maven, false, true, true, null ),
+            new OrFilter( new DependencyFilter( filterScope, ScopeTransitivity.maven, false, true, true, null ),
                           new DependencyFilter( DependencyScope.embedded, ScopeTransitivity.maven, false, true, true,
                                                 null ) );
+        this.excludes = exc;
     }
 
-    private ScopeWithEmbeddedProjectsFilter( final DependencyScope scope, final ProjectRelationshipFilter childFilter )
+    ScopeWithEmbeddedProjectsFilter( final ProjectRelationshipFilter childFilter, final boolean acceptManaged,
+                                     final Set<ProjectRef> excludes )
     {
-        this.acceptManaged = DEFAULT_CHILD_ACCEPTMANAGED;
-        this.filter =
-            childFilter == null ? new OrFilter( new DependencyFilter( scope, ScopeTransitivity.maven, false, true,
-                                                                      true, null ),
-                                                new DependencyFilter( DependencyScope.embedded,
-                                                                      ScopeTransitivity.maven, false, true, true, null ) )
-                            : childFilter;
+        this.acceptManaged = acceptManaged;
+        this.filter = childFilter;
+        this.excludes = excludes;
     }
 
     @Override
@@ -86,6 +92,11 @@ public class ScopeWithEmbeddedProjectsFilter
         else if ( !acceptManaged && rel.isManaged() )
         {
             result = false;
+        }
+        else if ( rel.getType() == DEPENDENCY )
+        {
+            result = ( excludes == null || !excludes.contains( rel.getTarget().asProjectRef() ) )
+                    && filter.accept( rel );
         }
         else
         {
@@ -132,24 +143,45 @@ public class ScopeWithEmbeddedProjectsFilter
                 //                logger.info( "getChildFilter({})", lastRelationship );
 
                 final DependencyRelationship dr = (DependencyRelationship) lastRelationship;
+
                 if ( DependencyScope.test == dr.getScope() || DependencyScope.provided == dr.getScope() )
                 {
-                    if ( acceptManaged == DEFAULT_CHILD_ACCEPTMANAGED && filter == NoneFilter.INSTANCE )
-                    {
-                        return this;
-                    }
-
                     logger.debug( "[FILT-OFFx2]: {}", lastRelationship );
-                    return new ScopeWithEmbeddedProjectsFilter( scope, NoneFilter.INSTANCE );
+                    return StructuralRelationshipsFilter.INSTANCE;
+                }
+                
+                Set<ProjectRef> exc = null;
+                boolean excChanged = false;
+                
+                // if there are new excludes, ALWAYS construct a new child filter.
+                if ( dr.getExcludes() != null && !dr.getExcludes().isEmpty() )
+                {
+                    if ( excludes != null )
+                    {
+                        exc = new HashSet<ProjectRef>( excludes );
+                        exc.addAll( dr.getExcludes() );
+                        excChanged = !exc.equals( excludes );
+                    }
+                    else
+                    {
+                        exc = new HashSet<ProjectRef>( dr.getExcludes() );
+                        excChanged = true;
+                    }
+                }
+                else if ( excludes != null )
+                {
+                    exc = new HashSet<ProjectRef>( excludes );
                 }
 
                 final ProjectRelationshipFilter nextFilter = filter.getChildFilter( lastRelationship );
-                if ( acceptManaged == DEFAULT_CHILD_ACCEPTMANAGED && nextFilter == filter )
+                if ( filter.equals( nextFilter ) && acceptManaged == DEFAULT_CHILD_ACCEPTMANAGED && !excChanged )
                 {
                     return this;
                 }
-
-                return new ScopeWithEmbeddedProjectsFilter( scope, nextFilter );
+                else
+                {
+                    return new ScopeWithEmbeddedProjectsFilter( nextFilter, DEFAULT_CHILD_ACCEPTMANAGED, exc );
+                }
             }
         }
     }
@@ -171,7 +203,9 @@ public class ScopeWithEmbeddedProjectsFilter
                 sb.append( filter.getLongId() );
             }
 
-            sb.append( ",acceptManaged:" )
+            sb.append( ",excludes:{" )
+              .append( new JoinString( ",", excludes ) )
+              .append( "},acceptManaged:" )
               .append( acceptManaged )
               .append( ")" );
 
@@ -194,7 +228,6 @@ public class ScopeWithEmbeddedProjectsFilter
         int result = 1;
         result = prime * result + ( acceptManaged ? 1231 : 1237 );
         result = prime * result + filter.hashCode();
-        result = prime * result + ( ( scope == null ) ? 0 : scope.hashCode() );
         return result;
     }
 
@@ -219,10 +252,6 @@ public class ScopeWithEmbeddedProjectsFilter
             return false;
         }
         if ( !filter.equals( other.filter ) )
-        {
-            return false;
-        }
-        if ( scope != other.scope )
         {
             return false;
         }

--- a/src/main/java/org/commonjava/maven/cartographer/preset/ScopedProjectFilter.java
+++ b/src/main/java/org/commonjava/maven/cartographer/preset/ScopedProjectFilter.java
@@ -49,7 +49,7 @@ public class ScopedProjectFilter
 
     public ScopedProjectFilter()
     {
-        this( DependencyScope.runtime, DEFAULT_ACCEPTMANAGED, null );
+        this( DependencyScope.runtime, DEFAULT_ACCEPTMANAGED );
     }
 
     public ScopedProjectFilter( final DependencyScope scope, final boolean acceptManaged )
@@ -155,10 +155,10 @@ public class ScopedProjectFilter
                 }
 
                 final ProjectRelationshipFilter nextFilter = filter.getChildFilter( lastRelationship );
-                boolean construct = excChanged || acceptManaged != DEFAULT_ACCEPTMANAGED || nextFilter != filter;
+                boolean construct = excChanged || nextFilter != filter;
                 if ( construct )
                 {
-                    return new ScopedProjectFilter( nextFilter, DEFAULT_ACCEPTMANAGED, exc );
+                    return new ScopedProjectFilter( nextFilter, acceptManaged, exc );
                 }
 
                 return this;

--- a/src/main/java/org/commonjava/maven/cartographer/preset/ScopedProjectFilter.java
+++ b/src/main/java/org/commonjava/maven/cartographer/preset/ScopedProjectFilter.java
@@ -155,7 +155,7 @@ public class ScopedProjectFilter
                 }
 
                 final ProjectRelationshipFilter nextFilter = filter.getChildFilter( lastRelationship );
-                boolean construct = excChanged || nextFilter != filter;
+                boolean construct = excChanged || filter.equals( nextFilter );
                 if ( construct )
                 {
                     return new ScopedProjectFilter( nextFilter, acceptManaged, exc );

--- a/src/main/java/org/commonjava/maven/cartographer/util/MavenModelProcessor.java
+++ b/src/main/java/org/commonjava/maven/cartographer/util/MavenModelProcessor.java
@@ -28,6 +28,7 @@ import org.commonjava.maven.atlas.graph.rel.PluginRelationship;
 import org.commonjava.maven.atlas.graph.util.RelationshipUtils;
 import org.commonjava.maven.atlas.ident.ref.ArtifactRef;
 import org.commonjava.maven.atlas.ident.ref.InvalidRefException;
+import org.commonjava.maven.atlas.ident.ref.ProjectRef;
 import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
 import org.commonjava.maven.atlas.ident.util.JoinString;
 import org.commonjava.maven.atlas.ident.version.InvalidVersionSpecificationException;
@@ -41,6 +42,7 @@ import org.commonjava.maven.galley.maven.model.view.MavenPomView;
 import org.commonjava.maven.galley.maven.model.view.ParentView;
 import org.commonjava.maven.galley.maven.model.view.PluginDependencyView;
 import org.commonjava.maven.galley.maven.model.view.PluginView;
+import org.commonjava.maven.galley.maven.model.view.ProjectRefView;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -523,10 +525,27 @@ public class MavenModelProcessor
                     // force the InvalidVersionSpecificationException.
                     artifactRef.getVersionSpec();
 
+                    Set<ProjectRefView> exclusionsView = dep.getExclusions();
+                    ProjectRef[] excludes;
+                    if ( exclusionsView != null && !exclusionsView.isEmpty() )
+                    {
+                        excludes = new ProjectRef[exclusionsView.size()];
+                        int i = 0;
+                        for ( ProjectRefView exclusionView : exclusionsView )
+                        {
+                            excludes[i] = exclusionView.asProjectRef();
+                            i++;
+                        }
+                    }
+                    else
+                    {
+                        excludes = new ProjectRef[0];
+                    }
+
                     builder.withDependencies( new DependencyRelationship( source, location, projectRef, artifactRef,
                                                                           dep.getScope(),
                                                                           builder.getNextDependencyIndex( managed ),
-                                                                          managed ) );
+                                                                          managed, excludes ) );
                 }
                 catch ( final InvalidRefException e )
                 {


### PR DESCRIPTION
Mostly simplification of filter classes along with some fixes.

* Instead of adding properties to configure a filter class it is better in some cases to use another already existing filter class.
* Exclusions in dependencies are now handled in more filters.
* Also fixes several bugs in checks if a new instance of a filter is needed or not.
* Always pass the acceptManaged value to childFilters instead of using a magic default value.